### PR TITLE
fix: keys for nodes should be something or null

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -96,6 +96,7 @@ export function importAssertions(Parser) {
         if (this.type !== tt.string) { this.unexpected(); }
         node.source = this.parseExprAtom();
 
+        node.assertions = null;
         if (this.type === this.assertToken) {
           this.next();
           const assertions = this.parseImportAssertions();
@@ -133,9 +134,11 @@ export function importAssertions(Parser) {
           { this.checkExport(exports, node.declaration.id.name, node.declaration.id.start); }
         node.specifiers = [];
         node.source = null;
+        node.assertions = null;
       } else { // export { x, y as z } [from '...']
         node.declaration = null;
         node.specifiers = this.parseExportSpecifiers(exports);
+        node.assertions = null;
         if (this.eatContextual("from")) {
           if (this.type !== tt.string) { this.unexpected(); }
           node.source = this.parseExprAtom();
@@ -177,6 +180,7 @@ export function importAssertions(Parser) {
           this.type === tt.string ? this.parseExprAtom() : this.unexpected();
       }
 
+      node.assertions = null;
       if (this.type === this.assertToken) {
         this.next();
         const assertions = this.parseImportAssertions();

--- a/test/fixtures/export-statement-without-assertions/expected.json
+++ b/test/fixtures/export-statement-without-assertions/expected.json
@@ -117,7 +117,8 @@
         ],
         "value": "./foo.json",
         "raw": "\"./foo.json\""
-      }
+      },
+      "assertions": null
     }
   ],
   "sourceType": "module"

--- a/test/fixtures/without-assertions/expected.json
+++ b/test/fixtures/without-assertions/expected.json
@@ -96,7 +96,8 @@
         ],
         "value": "./foo.json",
         "raw": "\"./foo.json\""
-      }
+      },
+      "assertions": null
     },
     {
       "type": "ImportDeclaration",
@@ -197,7 +198,8 @@
         ],
         "value": "./f.js",
         "raw": "\"./f.js\""
-      }
+      },
+      "assertions": null
     }
   ],
   "sourceType": "module"


### PR DESCRIPTION
Currently, the `assertions` key of a node can get an `object` value, or `null`, or `undefined`. The latter case should not happen: the value should either be something or null.

# Why does it matter?

Third party tools, e.g. rollup, assume that if no value exists, it should be `null` (e.g. [here](https://github.com/rollup/rollup/blob/master/src/ast/nodes/shared/Node.ts#L171)). If it encounters `undefined` instead, the code will break with an error.

# Is it not an issue with those third party tools instead?

No. Even if it could be argued tools depending on acorn should be written in a more robust manner, acorn has consistently used `null` when there was no value available. This behaviour should remain.