### PR TITLE
feat: support for arbitrary expressions in dynamic import attributes

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -72,8 +72,8 @@ export function importAttributes(Parser) {
       node.source = this.parseMaybeAssign();
 
       if (this.eat(tt.comma)) {
-        const obj = this.parseObj(false);
-        node.arguments = [obj];
+        const expr = this.parseExpression();
+        node.arguments = [expr];
       }
       this._eat(tt.parenR);
       return this.finishNode(node, "ImportExpression");


### PR DESCRIPTION
Currently, only object literals are supported as a second parameter to `import()`:

```JavaScript
await import('file.js', {});
```

However, NodeJS supports arbitrary expressions that evaluate to objects:

```JavaScript
const opt = {};
await import('file.js', opt);
```

This pull request expands support to include the behaviour from NodeJS.
