### PR TITLE
#24 Reference `test262` from GitHub using full URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "acorn": "^8.4.1",
     "chai": "^4.3.4",
     "mocha": "^9.1.0",
-    "test262": "tc39/test262#47ab262658cd97ae35c9a537808cac18fa4ab567",
+    "test262": "https://github.com/tc39/test262#47ab262658cd97ae35c9a537808cac18fa4ab567",
     "test262-parser-runner": "^0.5.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
Because some security tools consider the implied author+repo a dependency-confusion vulnerability.

Resolves #24 