### PR TITLE
feat: enable export-all to have a quoted name

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,14 +26,14 @@
     "@babel/core": "^7.15.0",
     "@babel/preset-env": "^7.15.0",
     "@babel/register": "^7.15.3",
-    "acorn": "^8.4.1",
+    "acorn": "^8.7.1",
     "chai": "^4.3.4",
     "mocha": "^9.1.0",
     "test262": "https://github.com/tc39/test262#39168e26c8b17782994388f8a7b59a8173f5de83",
     "test262-parser-runner": "^0.5.0"
   },
   "peerDependencies": {
-    "acorn": "^8"
+    "acorn": "^8.7.1"
   },
   "repository": {
     "type": "git",

--- a/src/index.js
+++ b/src/index.js
@@ -132,8 +132,8 @@ function pluginImpl(options, Parser) {
       if (this.eat(tt.star)) {
         if (this.options.ecmaVersion >= 11) {
           if (this.eatContextual("as")) {
-            node.exported = this.parseIdent(true);
-            this.checkExport(exports, node.exported.name, this.lastTokStart);
+            node.exported = this.parseExprAtom();
+            this.checkExport(exports, node.exported, this.lastTokStart);
           } else {
             node.exported = null;
           }

--- a/test/fixtures/export-statement-all-as-quoted-type/actual.js
+++ b/test/fixtures/export-statement-all-as-quoted-type/actual.js
@@ -1,0 +1,1 @@
+export * as "xx" from "./foo.json" with { type: "json" }

--- a/test/fixtures/export-statement-all-as-quoted-type/expected.json
+++ b/test/fixtures/export-statement-all-as-quoted-type/expected.json
@@ -1,0 +1,145 @@
+{
+  "type": "Program",
+  "start": 0,
+  "end": 57,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 2,
+      "column": 0
+    }
+  },
+  "range": [
+    0,
+    57
+  ],
+  "body": [
+    {
+      "type": "ExportAllDeclaration",
+      "start": 0,
+      "end": 56,
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 0
+        },
+        "end": {
+          "line": 1,
+          "column": 56
+        }
+      },
+      "range": [
+        0,
+        56
+      ],
+      "exported": {
+        "type": "Literal",
+        "start": 12,
+        "end": 16,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 12
+          },
+          "end": {
+            "line": 1,
+            "column": 16
+          }
+        },
+        "range": [
+          12,
+          16
+        ],
+        "value": "xx",
+        "raw": "\"xx\""
+      },
+      "source": {
+        "type": "Literal",
+        "start": 22,
+        "end": 34,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 22
+          },
+          "end": {
+            "line": 1,
+            "column": 34
+          }
+        },
+        "range": [
+          22,
+          34
+        ],
+        "value": "./foo.json",
+        "raw": "\"./foo.json\""
+      },
+      "attributes": [
+        {
+          "type": "ImportAttribute",
+          "start": 42,
+          "end": 54,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 42
+            },
+            "end": {
+              "line": 1,
+              "column": 54
+            }
+          },
+          "range": [
+            42,
+            54
+          ],
+          "key": {
+            "type": "Identifier",
+            "start": 42,
+            "end": 46,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 42
+              },
+              "end": {
+                "line": 1,
+                "column": 46
+              }
+            },
+            "range": [
+              42,
+              46
+            ],
+            "name": "type"
+          },
+          "value": {
+            "type": "Literal",
+            "start": 48,
+            "end": 54,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 48
+              },
+              "end": {
+                "line": 1,
+                "column": 54
+              }
+            },
+            "range": [
+              48,
+              54
+            ],
+            "value": "json",
+            "raw": "\"json\""
+          }
+        }
+      ]
+    }
+  ],
+  "sourceType": "module"
+}


### PR DESCRIPTION
Support quoted names in export-all:

```js
export * as "xx" from "./foo.json"
```

Imports are already covered because the plugin calls into `parseImportSpecifiers`.

The required version of acorn has been increased to 1.8.1 because that's when [checkExport became able to check quoted exports](https://github.com/acornjs/acorn/commit/84eda6bf47eb342950eeaa5992cc2ba81d648acf#diff-781c700ea716836ca6843f093b6a7d486849dec5b3c1ab428c6ce286592913dfR906-R909).

Closes #20